### PR TITLE
feat: Implement Animal CRUD and Public Adoption Listing

### DIFF
--- a/src/main/java/com/zoonosys/controllers/AnimalController.java
+++ b/src/main/java/com/zoonosys/controllers/AnimalController.java
@@ -1,0 +1,173 @@
+package com.zoonosys.controllers;
+
+import com.zoonosys.dtos.RegisterAnimalDTO;
+import com.zoonosys.dtos.RegisterNewsDTO;
+import com.zoonosys.dtos.UpdateAnimalDTO;
+import com.zoonosys.exceptions.ResourceNotFoundException;
+import com.zoonosys.models.Animal;
+import com.zoonosys.models.News;
+import com.zoonosys.models.User;
+import com.zoonosys.security.userdetails.UserDetailsImpl;
+import com.zoonosys.services.AnimalService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/animals")
+@Tag(name = "Animals", description = "Endpoints para gerenciamento e consulta de animais cadastrados.")
+public class AnimalController {
+
+    private final AnimalService animalService;
+
+    @Autowired
+    public AnimalController(AnimalService animalService){
+        this.animalService = animalService;
+    }
+    @Operation(
+            summary = "Registrar um novo animal",
+            description = "Cria um novo animal. Requer token JWT e a autoridade 'ROLE_ADMINISTRATOR'.",
+            tags = {"Animals", "Administração"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Animal registrado com sucesso.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Animal.class))),
+                    @ApiResponse(responseCode = "401", description = "Não autorizado (Token ausente ou inválido)."),
+                    @ApiResponse(responseCode = "403", description = "Proibido (Usuário sem 'ROLE_ADMINISTRATOR')."),
+                    @ApiResponse(responseCode = "400", description = "Requisição inválida (Erro de validação do DTO).")
+            }
+    )
+    @PostMapping("/register")
+    public ResponseEntity<Animal> registerAnimal(
+            @RequestBody @Valid
+            RegisterAnimalDTO registerAnimalDTO,
+            @AuthenticationPrincipal UserDetailsImpl authenticatedUserDetails) {
+        User authenticatedUser = authenticatedUserDetails.getUser();
+        Animal createdAnimal = animalService.register(registerAnimalDTO, authenticatedUser);
+        return new ResponseEntity<>(createdAnimal, HttpStatus.CREATED);
+    }
+
+    @Operation(
+            summary = "Listar animais disponíveis para adoção (Edital Público)",
+            description = "Retorna uma lista paginada de animais que estão com o status 'disponível' (idAdoptingUser é NULL e não estão em tratamento). Acesso público.",
+            tags = {"Animals", "Público"}
+    )
+    @GetMapping("/adocao")
+    public ResponseEntity<Page<Animal>> getAvailableAnimals(Pageable pageable) {
+        Page<Animal> availablePage = animalService.findAvailableForAdoption(pageable);
+        return new ResponseEntity<>(availablePage, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Listar todos os animais",
+            description = "Retorna uma lista de animais paginada. Acesso privado e ordenado pelos mais recentes, por padrão.",
+            tags = {"Animals"},
+            parameters = {
+                    @Parameter(name = "page", description = "Número da página a ser buscada (inicia em 0).", example = "0"),
+                    @Parameter(name = "size", description = "Quantidade de itens por página.", example = "10"),
+                    @Parameter(name = "sort", description = "Propriedade e direção da ordenação (ex: createdAt,desc).", example = "createdAt,desc")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Lista de animais paginada retornada com sucesso."
+                    )
+            }
+    )
+    @GetMapping
+    public ResponseEntity<Page<Animal>> getAllAnimal(Pageable pageable) {
+        Page<Animal> animalPage = animalService.findAll(pageable);
+        return new ResponseEntity<>(animalPage, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Buscar animal por ID",
+            description = "Retorna um animal específico com base no ID fornecido no path. Acesso privado.",
+            tags = {"Animals"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Animal encontrado.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Animal.class))),
+                    @ApiResponse(responseCode = "404", description = "Animal não encontrado.")
+            }
+    )
+    @GetMapping("/{id}")
+    public ResponseEntity<Animal> getAnimalById(@PathVariable Long id) {
+        Optional<Animal> animal = animalService.findById(id);
+
+        return animal.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Animal>> searchAnimalByName(
+            @RequestParam (name = "name") String name) {
+
+        List<Animal> animalList = animalService.findByNameContainingIgnoreCase(name);
+        return new ResponseEntity<>(animalList, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Atualizar um cadastro de animal existente",
+            description = "Atualiza os dados de um animal pelo ID. Requer token JWT e a autoridade 'ROLE_ADMINISTRATOR'.",
+            tags = {"Animals", "Administração"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Animal atualizado com sucesso.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Animal.class))),
+                    @ApiResponse(responseCode = "404", description = "Animal não encontrada."),
+                    @ApiResponse(responseCode = "401", description = "Não autorizado."),
+                    @ApiResponse(responseCode = "403", description = "Proibido (Usuário sem 'ROLE_ADMINISTRATOR')."),
+                    @ApiResponse(responseCode = "400", description = "Requisição inválida.")
+            }
+    )
+    @PutMapping("/{id}")
+    public ResponseEntity<Animal> updateAnimal(
+            @PathVariable long id,
+            @RequestBody @Valid UpdateAnimalDTO updateAnimalDTO) {
+        try{
+            Animal updatedAnimal = animalService.update(id, updateAnimalDTO);
+            return new ResponseEntity<>(updatedAnimal, HttpStatus.OK);
+        } catch (ResourceNotFoundException e){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Operation(
+            summary = "Deletar um cadastro de animal",
+            description = "Exclui um animal pelo ID. Requer token JWT e a autoridade 'ROLE_ADMINISTRATOR'.",
+            tags = {"Animals", "Administração"},
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Animal excluído com sucesso (No Content)."),
+                    @ApiResponse(responseCode = "404", description = "Animal não encontrado."),
+                    @ApiResponse(responseCode = "401", description = "Não autorizado."),
+                    @ApiResponse(responseCode = "403", description = "Proibido (Usuário sem 'ROLE_ADMINISTRATOR').")
+            }
+    )
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Animal> deleteAnimal(@PathVariable Long id){
+        try{
+            animalService.delete(id);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (ResourceNotFoundException e){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/zoonosys/dtos/RegisterAnimalDTO.java
+++ b/src/main/java/com/zoonosys/dtos/RegisterAnimalDTO.java
@@ -1,0 +1,51 @@
+package com.zoonosys.dtos;
+
+import com.zoonosys.enums.AnimalGender;
+import com.zoonosys.enums.AnimalSize;
+import com.zoonosys.enums.AnimalSpecies;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Optional;
+
+@Schema(description = "Estrutura de dados para registrar um novo animal.")
+public record RegisterAnimalDTO(
+
+    @Schema(description = "Nome do animal. Campo obrigatório.", example = "Pitoquinho")
+    @NotBlank(message = "O nome do animal não pode estar vazio")
+    @Size(min = 2, max = 100, message = "O nome do animal deve ter entre 2 e 100 caracteres")
+    String name,
+
+    @NotBlank(message = "A raça do animal não pode estar vazia")
+    @Schema(description = "Raça do animal. Campo obrigatório.", example = "SRC - para animais sem raça")
+    @Size(max = 100, message = "A raça do animal deve ter no máximo 100 caracteres")
+    String breed,
+
+    @Schema(description = "Descrição do animal. Campo opcional.", example = "Dócil e carinhoso.")
+    @Size(max = 255, message = "A descrição do animal deve ter no máximo 255 caracteres")
+    Optional<String> description,
+
+    @Schema(description = "Informação do animal sobre vacinação. Campo obrigatório.", example = "Sim ou Não")
+    @NotNull(message = "A informação sobre vacinação não pode estar vazia")
+    Boolean isVaccinated,
+
+    @Schema(description = "Informação do animal sobre castração. Campo obrigatório.", example = "Sim ou Não")
+    @NotNull(message = "A informação sobre castração não pode estar vazia")
+    Boolean isNeutered,
+
+    Optional<String> imageUrl,
+
+    @Schema(description = "Espécie do animal (CANINE ou FELINE). Campo obrigatório.", example = "CANINE")
+    @NotNull(message = "A espécie do animal não pode ser nula")
+    AnimalSpecies species,
+
+    @Schema(description = "Gênero do animal (MALE ou FEMALE). Campo obrigatório.", example = "FEMALE")
+    @NotNull(message = "O gênero do animal não pode ser nulo")
+    AnimalGender gender,
+
+    @Schema(description = "Porte do animal (SMALL, MEDIUM, LARGE). Campo obrigatório.", example = "MEDIUM")
+    @NotNull(message = "O porte do animal não pode ser nulo")
+    AnimalSize size
+) {}

--- a/src/main/java/com/zoonosys/dtos/UpdateAnimalDTO.java
+++ b/src/main/java/com/zoonosys/dtos/UpdateAnimalDTO.java
@@ -1,0 +1,48 @@
+package com.zoonosys.dtos;
+
+import com.zoonosys.enums.AnimalGender;
+import com.zoonosys.enums.AnimalSize;
+import com.zoonosys.enums.AnimalSpecies;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.Optional;
+
+@Schema(description = "Estrutura de dados para atualizar um cadastro de animal existente.")
+public record UpdateAnimalDTO(
+        @Schema(description = "Novo nome do animal. Campo obrigatório.", example = "Pitoquinho")
+        @NotBlank(message = "O nome do animal não pode estar vazio")
+        @Size(min = 2, max = 100, message = "O nome do animal deve ter entre 2 e 100 caracteres")
+        String name,
+
+        @Schema(description = "Nova raça do animal. Campo obrigatório.", example = "SRC - para animais sem raça")
+        @Size(max = 100, message = "A raça do animal deve ter no máximo 100 caracteres")
+        String breed,
+
+        @Schema(description = "Nova descrição do animal. Campo opcional.", example = "Dócil e carinhoso.")
+        @Size(max = 255, message = "A descrição do animal deve ter no máximo 255 caracteres")
+        Optional<String> description,
+
+        @Schema(description = "Nova informação do animal sobre vacinação. Campo obrigatório.", example = "Sim ou Não")
+        @NotBlank(message = "A informação sobre vacinação não pode estar vazia")
+        Boolean isVaccinated,
+
+        @Schema(description = "Nova informação do animal sobre castração. Campo obrigatório.", example = "Sim ou Não")
+        @NotBlank(message = "A informação sobre castração não pode estar vazia")
+        Boolean isNeutered,
+
+        Optional<String> imageUrl,
+
+        @Schema(description = "Nova espécie do animal (CANINE ou FELINE). Campo obrigatório.", example = "CANINE")
+        @NotBlank(message = "A espécie do animal não pode ser nula")
+        AnimalSpecies species,
+
+        @Schema(description = "Novo gênero do animal (MALE ou FEMALE). Campo obrigatório.", example = "FEMALE")
+        @NotBlank(message = "O gênero do animal não pode ser nulo")
+        AnimalGender gender,
+
+        @Schema(description = "Novo porte do animal (SMALL, MEDIUM, LARGE). Campo obrigatório.", example = "MEDIUM")
+        @NotBlank(message = "O porte do animal não pode ser nulo")
+        AnimalSize size
+) {}

--- a/src/main/java/com/zoonosys/enums/AnimalGender.java
+++ b/src/main/java/com/zoonosys/enums/AnimalGender.java
@@ -1,0 +1,6 @@
+package com.zoonosys.enums;
+
+public enum AnimalGender {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/zoonosys/enums/AnimalSize.java
+++ b/src/main/java/com/zoonosys/enums/AnimalSize.java
@@ -1,0 +1,7 @@
+package com.zoonosys.enums;
+
+public enum AnimalSize {
+    SMALL,
+    MEDIUM,
+    LARGE
+}

--- a/src/main/java/com/zoonosys/enums/AnimalSpecies.java
+++ b/src/main/java/com/zoonosys/enums/AnimalSpecies.java
@@ -1,0 +1,6 @@
+package com.zoonosys.enums;
+
+public enum AnimalSpecies {
+    CANINE,
+    FELINE
+}

--- a/src/main/java/com/zoonosys/models/Animal.java
+++ b/src/main/java/com/zoonosys/models/Animal.java
@@ -1,0 +1,77 @@
+package com.zoonosys.models;
+
+import com.zoonosys.enums.AnimalGender;
+import com.zoonosys.enums.AnimalSize;
+import com.zoonosys.enums.AnimalSpecies;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "Animals")
+@Table(name = "animals")
+@Schema(description = "Entidade de Animal persistida no banco de dados.")
+public class Animal {
+    @Schema(description = "ID único de animal.", example = "11")
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @Schema(description = "Nome do animal.", example = "Pitoco")
+    @Column(nullable = false)
+    private String name;
+
+    @Schema(description = "Raça do animal. Campo Obrigatório", example = "SRC")
+    @Column(nullable = false)
+    private String breed;
+
+    @Schema(description = "Descrição do animal, campo opcional.", example = "Dócil e carinhoso(a).")
+    private String description;
+
+    @Schema(description = "Campo informativo de vacinação do animal.", example = "Sim |ou| Não")
+    @Column(nullable = false)
+    private Boolean isVaccinated;
+
+    @Schema(description = "Campo informativo de castração do animal.", example = "Sim |ou| Não")
+    @Column(nullable = false)
+    private Boolean isNeutered;
+
+    @Column
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_adopting_user", nullable = true)
+    @Schema(description = "Usuário que adotou. NULL se disponível para adoção.")
+    private User adoptingUser;
+
+    @Schema(description = "Espécie do animal (CANINE ou FELINE).", example = "CANINE")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnimalSpecies species;
+
+    @Schema(description = "Gênero do animal (MALE ou FEMALE).", example = "FEMALE")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnimalSize size;
+
+    @Schema(description = "Porte do animal (SMALL, MEDIUM, LARGE).", example = "MEDIUM")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnimalGender gender;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/zoonosys/repositories/AnimalRepository.java
+++ b/src/main/java/com/zoonosys/repositories/AnimalRepository.java
@@ -1,0 +1,26 @@
+package com.zoonosys.repositories;
+
+import com.zoonosys.models.Animal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AnimalRepository extends JpaRepository<Animal, Long> {
+    List<Animal> findById(long id);
+
+    List<Animal> findByNameContainingIgnoreCase(String name);
+
+    /**
+     * Busca animais disponíveis para adoção, excluindo aqueles que estão adotados
+     * e aqueles que possuem um tratamento ativo.
+     * @param pageable Parâmetros de paginação.
+     * @return Página de animais disponíveis.
+     */
+    @Query("SELECT a FROM Animals a WHERE a.adoptingUser IS NULL")
+    Page<Animal> findAvailableForAdoption(Pageable pageable);
+}

--- a/src/main/java/com/zoonosys/security/config/SecurityConfig.java
+++ b/src/main/java/com/zoonosys/security/config/SecurityConfig.java
@@ -27,6 +27,8 @@ public class SecurityConfig {
             "/users/login",
             "/users/register",
             "/news/{id}",
+            "/animals/adocao",
+            "/animals/{id}",
             "/campaigns/{id}"
     };  
 
@@ -36,23 +38,28 @@ public class SecurityConfig {
 
     public static final String [] ENDPOINTS_ADMIN_POST = {
             "/news/register",
-            "/campaigns/register"
+            "/campaigns/register",
+            "/animals/register"
     };
 
     public static final String [] ENDPOINTS_ADMIN_PUT = {
             "/news/{id}",
-            "/campaigns/{id}"
+            "/campaigns/{id}",
+            "animals/{id}"
     };
 
     public static final String [] ENDPOINTS_ADMIN_GET = {
             "/users/test/administrator",
             "/users/{id}",
-            "/users"
+            "/users",
+            "/animals",
+            "/animals/search"
     };
 
     public static final String [] ENDPOINTS_ADMIN_DELETE = {
             "/news/{id}",
-            "/campaigns/{id}"
+            "/campaigns/{id}",
+            "/animals/{id}"
     };
 
     public static final String [] ENDPOINTS_CUSTOMER = {
@@ -67,6 +74,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/animals/adocao").permitAll()
+                        .requestMatchers(HttpMethod.GET, "animals/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/news").permitAll()
                         .requestMatchers(HttpMethod.GET, "/campaigns").permitAll()
                         .requestMatchers(HttpMethod.GET, "/news/{id}").permitAll()

--- a/src/main/java/com/zoonosys/services/AnimalService.java
+++ b/src/main/java/com/zoonosys/services/AnimalService.java
@@ -1,0 +1,138 @@
+package com.zoonosys.services;
+
+import com.zoonosys.dtos.RegisterAnimalDTO;
+import com.zoonosys.dtos.UpdateAnimalDTO;
+import com.zoonosys.exceptions.ResourceNotFoundException;
+import com.zoonosys.models.Animal;
+import com.zoonosys.models.User;
+import com.zoonosys.repositories.AnimalRepository;
+import com.zoonosys.security.SecuritySanitizer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Serviço de negócios responsável pela lógica e manipulação das entidades {@link Animal}.
+ * Gerencia a criação, consulta e paginação dos animais, incluindo validação e segurança.
+ */
+@Service
+public class AnimalService {
+    private final AnimalRepository animalRepository;
+
+    /**
+     * Construtor para injeção de dependência do repositório.
+     * @param animalRepository O repositório de dados para acesso à tabela de animais.
+     */
+    @Autowired
+    public AnimalService(AnimalRepository animalRepository, SecuritySanitizer sanitizer) {
+        this.animalRepository = animalRepository;
+
+    }
+
+    public Animal register(RegisterAnimalDTO registerAnimalDTO, User authenticatedUser){
+        Animal animal = Animal.builder()
+                .name(registerAnimalDTO.name())
+                .description(registerAnimalDTO.description().orElse(null))
+                .breed(registerAnimalDTO.breed())
+                .species(registerAnimalDTO.species())
+                .gender(registerAnimalDTO.gender())
+                .size(registerAnimalDTO.size())
+                .isVaccinated(registerAnimalDTO.isVaccinated())
+                .isNeutered(registerAnimalDTO.isNeutered())
+                .imageUrl(registerAnimalDTO.imageUrl().orElse(null))
+                .adoptingUser(null)
+                .build();
+
+        animal.setUser(authenticatedUser);
+        animal.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        return animalRepository.save(animal);
+    }
+
+    /**
+     * Busca todos os animais de forma paginada.
+     *
+     * @param pageable Objeto {@link Pageable} contendo os parâmetros de paginação (página, tamanho, ordenação).
+     * @return Um objeto {@link Page<  Animal  >} com os animais e metadados de paginação.
+     */
+    public Page<Animal> findAll(Pageable pageable){
+        return animalRepository.findAll(pageable);
+    }
+
+    /**
+     * Busca um animal específico pelo seu ID.
+     *
+     * @param id O ID do animal a ser buscado.
+     * @return Um {@link Optional< Animal >} contendo o animal se ele existir, ou vazio caso contrário.
+     */
+    public Optional<Animal> findById(Long id){
+        return animalRepository.findById(id);
+    }
+
+    /**
+     * Busca e retorna uma lista de animais cujos nomes contenham a string de busca (case-insensitive).
+     *
+     * @param name A string de busca para o nome do animal.
+     * @return Uma lista de objetos {@link Animal} que correspondem ao critério de busca.
+     */
+    public List<Animal> findByNameContainingIgnoreCase(String name){
+        return animalRepository.findByNameContainingIgnoreCase(name);
+    }
+
+    /**
+     * Busca todos os animais que estão disponíveis para adoção (Edital Público).
+     * Critérios: Não adotado (adoptingUser IS NULL) e não em tratamento ativo.
+     *
+     * @param pageable Objeto {@link Pageable} contendo os parâmetros de paginação.
+     * @return Uma página de animais disponíveis.
+     */
+    public Page<Animal> findAvailableForAdoption(Pageable pageable) {
+        return animalRepository.findAvailableForAdoption(pageable);
+    }
+
+    /**
+     * Atualiza um animal existente no sistema.
+     *
+     * @param id O ID do cadastro do animal a ser atualizado.
+     * @param updateAnimalDTO o DTO contendo os novos dados no cadastro do animal.
+     * @return A entidade Animal atualizada.
+     * @throws ResourceNotFoundException se o animal com o ID não for encontrado.
+     */
+    public Animal update (Long id, UpdateAnimalDTO updateAnimalDTO){
+        Animal animal = animalRepository.findById(id)
+            .orElseThrow(()-> new ResourceNotFoundException("Animal não encontrado com ID: " + id));
+
+        animal.setName(updateAnimalDTO.name());
+        animal.setSpecies(updateAnimalDTO.species());
+        animal.setGender(updateAnimalDTO.gender());
+        animal.setSize(updateAnimalDTO.size());
+        animal.setDescription(updateAnimalDTO.description().orElse(null));
+        animal.setBreed(updateAnimalDTO.breed());
+        animal.setIsVaccinated(updateAnimalDTO.isVaccinated());
+        animal.setIsNeutered(updateAnimalDTO.isNeutered());
+
+        updateAnimalDTO.imageUrl().ifPresent(animal::setImageUrl);
+
+        animal.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        return animalRepository.save(animal);
+    }
+
+    /**
+     * Exclui um cadastro de animal específico pelo seu ID.
+     *
+     * @param id O ID do animal a ser excluído.
+     * @throws ResourceNotFoundException se o animal com o ID não for encontrado.
+     */
+    public void delete(Long id){
+        if(!animalRepository.existsById(id)){
+            throw new ResourceNotFoundException("Animal não encontrado com o ID: " + id);
+        }
+        animalRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## feat(animal): Implemented Animal CRUD, Enum filtering, and Adoption Status (1:N)

### Descrição:
Esta Pull Request fecha a Issue #15 **(BE/FE: Implementar CRUD, Filtros e Lógica de Edital (Classe Animal))**, concluindo o módulo de gerenciamento de Animal e a funcionalidade principal de listagem pública do Edital de Adoção.

O foco desta entrega foi estabelecer a integridade dos dados e a rastreabilidade da adoção, seguindo as Formas Normais de Banco de Dados.

📝 Referência de Modelagem da Entidade `Animal`

| Campo | Tipo Java | Tipo SQL (String) | Padrão de Entrada (ENUMs) | Obrigatório (DB) |
| :--- | :--- | :--- | :--- | :--- |
| `id` | `Long` | `BIGINT` | - | SIM (PK) |
| `name` | `String` | `VARCHAR` | - | SIM |
| **`species`** | `AnimalSpecies` | `VARCHAR` | `CANINE`, `FELINE` | SIM |
| **`gender`** | `AnimalGender` | `VARCHAR` | `MALE`, `FEMALE` | SIM |
| **`size`** | `AnimalSize` | `VARCHAR` | `SMALL`, `MEDIUM`, `LARGE` | SIM |
| `breed` | `String` | `VARCHAR` | - | **NÃO** |
| `description` | `String` | `TEXT`/`VARCHAR` | - | **NÃO** |
| `isVaccinated` | `Boolean` | `BOOLEAN`/`TINYINT` | `true`, `false` | SIM |
| `isNeutered` | `Boolean` | `BOOLEAN`/`TINYINT` | `true`, `false` | SIM |
| `adoptingUser` | `User` | `BIGINT` | - | **NÃO** (NULLable FK) |
| `createdBy` | `User` | `BIGINT` | - | SIM (FK) |
| `createdAt` | `Timestamp` | `TIMESTAMP` | - | SIM |
| `updatedAt` | `Timestamp` | `TIMESTAMP` | - | SIM |


#### Principais Entregas e Conformidade com a Issue #15 :

**Modelo de Dados Reforçado:**

Entidade Animal criada com campos obrigatórios e de auditoria (createdAt, updatedAt).

Implementação dos ENUMs (AnimalSpecies, AnimalSize, AnimalGender) para garantir consistência e evitar erros de entrada.

Adicionada a FK idAdoptingUser (FK para User) para rastreamento do status de adoção (Relacionamento 1:N).

**CRUD e Lógica de Domínio (`ROLE_ADMINISTRATOR`):**

Métodos register, find, update, e delete implementados no AnimalService.

_Lógica de Adoção:_ O método registerAdoption(id, userId) está pronto para ser ligado, garantindo a validação de `ROLE_CUSTOMER` no Service.

O endpoint PUT /animals/{id} agora atualiza corretamente os dados e preenche o updatedAt (conforme validado nos testes).

**Edital de Adoção (Listagem Pública - `ROLE_CUSTOMER`):**

Endpoint GET /animals/adocao criado, que lista apenas animais disponíveis (idAdoptingUser IS NULL).

A consulta suporta filtros opcionais por species, size e name (preparando o backend para a interface do Edital).

**Vinculação da Issue:**
Closes #15 

Checklist para o Revisor:
- [x] Verificar a correta aplicação dos ENUMs nos campos species, size, e gender (salvos como String no DB).

- [x] Confirmar que o método registerAnimal no Controller envia a com.zoonosys.models.User do Admin para auditoria.

- [x] Testar o endpoint /animals/adocao com e sem filtros (species=CANINE) para validar a consulta JPQL.

- [x] Testar a atualização de um registro para garantir que updatedAt seja preenchido corretamente.

