### PR TITLE
feat(auth): Complete and Secure Password Reset Flow

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,6 @@ SERVER_CONTEXT_PATH="/api"
 
 DB_USERNAME=postgres
 DB_PASSWORD=senha
+
+MAIL_USERNAME=danielle.bortoleto3412@gmail.com
+MAIL_PASSWORD="qusk ivnm mndq bygd"

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
-
-			
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -122,6 +120,21 @@
             <groupId>io.github.cdimascio</groupId>
             <artifactId>dotenv-java</artifactId>
             <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>6.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+            <version>3.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <version>3.5.4</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/java/com/zoonosys/DemoApplication.java
+++ b/src/main/java/com/zoonosys/DemoApplication.java
@@ -15,6 +15,8 @@ public class DemoApplication {
         System.setProperty("SERVER_PORT", dotenv.get("SERVER_PORT"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        System.setProperty("spring.mail.username", dotenv.get("MAIL_USERNAME"));
+        System.setProperty("spring.mail.password", dotenv.get("MAIL_PASSWORD"));
 
         SpringApplication.run(DemoApplication.class, args);
 	}

--- a/src/main/java/com/zoonosys/DemoApplication.java
+++ b/src/main/java/com/zoonosys/DemoApplication.java
@@ -3,7 +3,9 @@ package com.zoonosys;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/com/zoonosys/controllers/PasswordResetController.java
+++ b/src/main/java/com/zoonosys/controllers/PasswordResetController.java
@@ -1,0 +1,4 @@
+package com.zoonosys.controllers;
+
+public class PasswordResetController {
+}

--- a/src/main/java/com/zoonosys/controllers/PasswordResetController.java
+++ b/src/main/java/com/zoonosys/controllers/PasswordResetController.java
@@ -6,6 +6,7 @@ import com.zoonosys.exceptions.UserNotFoundException;
 import com.zoonosys.models.PasswordResetToken;
 import com.zoonosys.models.User;
 import com.zoonosys.services.PasswordResetService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,10 +59,12 @@ public class PasswordResetController {
 
     /**
      * Endpoint para confirmar a redefinição de senha.
-     * @param confirmation DTO com o token, nova senha e confirmação.
+     * @param tokenValue O token de reset de senha (vindo da URL).
+     * @param confirmation DTO com a nova senha e confirmação (vindo do corpo).
      * @return 200 OK se a senha for redefinida, 400 Bad Request caso contrário.
      */
-
+    @Operation(summary = "Confirma a redefinição de senha",
+            description = "Valida o token da URL, verifica a nova senha e a aplica ao usuário, invalidando todos os tokens ativos.")
     @PostMapping("/reset-password/confirm")
     public ResponseEntity<String> confirmPasswordReset(
             @RequestParam("token") String tokenValue,

--- a/src/main/java/com/zoonosys/controllers/PasswordResetController.java
+++ b/src/main/java/com/zoonosys/controllers/PasswordResetController.java
@@ -1,4 +1,87 @@
 package com.zoonosys.controllers;
 
+import com.zoonosys.dtos.ResetPasswordConfirmationDTO;
+import com.zoonosys.dtos.ResetPasswordRequestDTO;
+import com.zoonosys.exceptions.UserNotFoundException;
+import com.zoonosys.models.PasswordResetToken;
+import com.zoonosys.models.User;
+import com.zoonosys.services.PasswordResetService;
+import jakarta.validation.Valid;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/auth")
 public class PasswordResetController {
+    private static final Logger logger = LoggerFactory.getLogger(PasswordResetController.class);
+
+    @Autowired
+    private PasswordResetService resetService;
+
+    @PostMapping("/reset-password/request")
+    public ResponseEntity<String> requestPasswordReset(@Valid @RequestBody ResetPasswordRequestDTO request) {
+
+        try {
+            resetService.createAndSendResetToken(request);
+            return ResponseEntity.ok("Se o e-mail estiver registrado, um link de reset foi enviado.");
+
+        } catch (UserNotFoundException e) {
+            logger.warn("Tentativa de reset de senha falhou para e-mail não encontrado: {}", request.email());
+            return ResponseEntity.ok("Se o e-mail estiver registrado, um link de reset foi enviado.");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Falha na solicitação de reset.");
+        }
+    }
+
+    /**
+     * Endpoint para validar o token recebido no link de e-mail.
+     * @param tokenValue de reset de senha.
+     * @return 200 OK se válido, 400 Bad Request caso contrário.
+     */
+    @GetMapping("/reset-password/validate")
+    public ResponseEntity<?> validatePasswordResetToken(@RequestParam("token") String tokenValue) {
+        Optional<PasswordResetToken> validToken = resetService.validateToken(tokenValue);
+
+        if (validToken.isPresent()) {
+            return ResponseEntity.ok().body("Token válido. Prossiga para a redefinição de senha.");
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Token de reset inválido, expirado ou já utilizado.");
+        }
+    }
+
+    /**
+     * Endpoint para confirmar a redefinição de senha.
+     * @param confirmation DTO com o token, nova senha e confirmação.
+     * @return 200 OK se a senha for redefinida, 400 Bad Request caso contrário.
+     */
+
+    @PostMapping("/reset-password/confirm")
+    public ResponseEntity<String> confirmPasswordReset(
+            @RequestParam("token") String tokenValue,
+            @Valid @RequestBody ResetPasswordConfirmationDTO confirmation
+    ) {
+        try {
+            Optional<User> userOptional = resetService.resetPassword(
+                    tokenValue,
+                    confirmation.newPassword(),
+                    confirmation.confirmationPassword()
+            );
+
+            if(userOptional.isPresent()){
+                return ResponseEntity.ok("Senha redefinida com sucesso.");
+            } else{
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Falha na redefinição de senha. Verifique o token ou se as senhas coincidem.");
+            }
+        }catch (Exception e){
+            logger.error("Error inesperado durante a redefinição de senha: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Ocorreu um erro interno ao tentar redefinir a senha.");
+        }
+    }
 }

--- a/src/main/java/com/zoonosys/dtos/ResetPasswordConfirmationDTO.java
+++ b/src/main/java/com/zoonosys/dtos/ResetPasswordConfirmationDTO.java
@@ -1,4 +1,16 @@
 package com.zoonosys.dtos;
 
-public class ResetPasswordConfirmationDTO {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public record ResetPasswordConfirmationDTO(
+        @NotBlank(message = "A nova senha é obrigatória.")
+        @Size(min = 8, message = "A senha deve ter no mínimo 8 caracteres.")
+        String newPassword,
+
+        @NotBlank(message = "A confirmação da senha é obrigatória.")
+        String confirmationPassword
+) {
 }

--- a/src/main/java/com/zoonosys/dtos/ResetPasswordConfirmationDTO.java
+++ b/src/main/java/com/zoonosys/dtos/ResetPasswordConfirmationDTO.java
@@ -1,0 +1,4 @@
+package com.zoonosys.dtos;
+
+public class ResetPasswordConfirmationDTO {
+}

--- a/src/main/java/com/zoonosys/dtos/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/zoonosys/dtos/ResetPasswordRequestDTO.java
@@ -1,0 +1,4 @@
+package com.zoonosys.dtos;
+
+public record ResetPasswordRequestDTO() {
+}

--- a/src/main/java/com/zoonosys/dtos/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/zoonosys/dtos/ResetPasswordRequestDTO.java
@@ -1,4 +1,10 @@
 package com.zoonosys.dtos;
 
-public record ResetPasswordRequestDTO() {
-}
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ResetPasswordRequestDTO(
+        @NotBlank(message = "O e-mail é obrigatório.")
+        @Email(message = "O formato do e-mail é inválido.")
+        String email
+) {}

--- a/src/main/java/com/zoonosys/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/zoonosys/exceptions/UserNotFoundException.java
@@ -1,4 +1,7 @@
 package com.zoonosys.exceptions;
 
-public class UserNotFoundException {
+public class UserNotFoundException extends ResourceNotFoundException{
+    public UserNotFoundException(String message){
+        super(message);
+    }
 }

--- a/src/main/java/com/zoonosys/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/zoonosys/exceptions/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package com.zoonosys.exceptions;
+
+public class UserNotFoundException {
+}

--- a/src/main/java/com/zoonosys/models/PasswordResetToken.java
+++ b/src/main/java/com/zoonosys/models/PasswordResetToken.java
@@ -1,4 +1,41 @@
 package com.zoonosys.models;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_password_reset_token")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 36)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "expiry_date", nullable = false)
+    private LocalDateTime expiryDate;
+
+    @Column(nullable = false)
+    private Boolean used = false;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public boolean isExpired(){
+        return LocalDateTime.now().isAfter(this.expiryDate);
+    }
 }

--- a/src/main/java/com/zoonosys/models/PasswordResetToken.java
+++ b/src/main/java/com/zoonosys/models/PasswordResetToken.java
@@ -1,0 +1,4 @@
+package com.zoonosys.models;
+
+public class PasswordResetToken {
+}

--- a/src/main/java/com/zoonosys/models/User.java
+++ b/src/main/java/com/zoonosys/models/User.java
@@ -1,14 +1,12 @@
 package com.zoonosys.models;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
+++ b/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
@@ -1,0 +1,4 @@
+package com.zoonosys.repositories;
+
+public interface PasswordResetTokenRepository {
+}

--- a/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
+++ b/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
@@ -2,6 +2,7 @@ package com.zoonosys.repositories;
 
 import com.zoonosys.models.PasswordResetToken;
 import com.zoonosys.models.User;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,7 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
     Optional<PasswordResetToken> findByToken(String token);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM PasswordResetToken t WHERE t.expiryDate <= :currentTime OR t.used = true")
     int deleteExpiredAndUsedTokens(@Param("currentTime") LocalDateTime currentTime);
 

--- a/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
+++ b/src/main/java/com/zoonosys/repositories/PasswordResetTokenRepository.java
@@ -1,4 +1,25 @@
 package com.zoonosys.repositories;
 
-public interface PasswordResetTokenRepository {
+import com.zoonosys.models.PasswordResetToken;
+import com.zoonosys.models.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+
+    @Modifying
+    @Query("DELETE FROM PasswordResetToken t WHERE t.expiryDate <= :currentTime OR t.used = true")
+    int deleteExpiredAndUsedTokens(@Param("currentTime") LocalDateTime currentTime);
+
+    @Modifying
+    @Query("DELETE FROM PasswordResetToken t WHERE t.user = :user AND t.used = false")
+    void deleteAllByUserAndUsedIsFalse(@Param("user")User user);
 }

--- a/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
+++ b/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
@@ -16,7 +16,7 @@ public class OpenApiConfig {
                     .title("ZoonoSys Documentation")
                     .version("1.0")
                     .description("Documentation Api ZoonoSys")
-    //              .termsOfService("www.daniellefbortoleto.com.br")
+                        .termsOfService("www.daniellefbortoleto.com.br")
                     .license(
                             new License()
                                     .name("Apache License 2.0")

--- a/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
+++ b/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
@@ -15,8 +15,8 @@ public class OpenApiConfig {
                 .info(new Info()
                     .title("ZoonoSys Documentation")
                     .version("1.0")
-                    .description("Documentation Api ZoonoSys")
-                        .termsOfService("www.daniellefbortoleto.com.br")
+                    .description("Api Documentation ZoonoSys")
+                        .termsOfService("http://localhost:8080")
                     .license(
                             new License()
                                     .name("Apache License 2.0")

--- a/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
+++ b/src/main/java/com/zoonosys/security/config/OpenApiConfig.java
@@ -7,10 +7,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class OpenAiConfig {
+public class OpenApiConfig {
 
     @Bean
-    public OpenAPI customOpenAi(){
+    public OpenAPI customOpenApi(){
         return new OpenAPI()
                 .info(new Info()
                     .title("ZoonoSys Documentation")

--- a/src/main/java/com/zoonosys/security/config/SecurityConfig.java
+++ b/src/main/java/com/zoonosys/security/config/SecurityConfig.java
@@ -1,9 +1,12 @@
 package com.zoonosys.security.config;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,6 +18,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import com.zoonosys.security.authentication.UserAuthenticationFilter;
+
+import java.util.Properties;
 
 @Configuration
 @EnableWebSecurity
@@ -29,7 +34,10 @@ public class SecurityConfig {
             "/news/{id}",
             "/animals/adocao",
             "/animals/{id}",
-            "/campaigns/{id}"
+            "/campaigns/{id}",
+            "/auth/reset-password/request",
+            "/auth/reset-password/validate",
+            "/auth/reset-password/confirm"
     };  
 
     public static final String [] ENDPOINTS_WITH_AUTHENTICATION_REQUIRED = {
@@ -75,11 +83,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/animals/adocao").permitAll()
-                        .requestMatchers(HttpMethod.GET, "animals/{id}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/animals/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/news").permitAll()
                         .requestMatchers(HttpMethod.GET, "/campaigns").permitAll()
                         .requestMatchers(HttpMethod.GET, "/news/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/campaigns/{id}").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/reset-password/request").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/reset-password/confirm").permitAll()
                         .requestMatchers(ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED).permitAll()
                         .requestMatchers(HttpMethod.GET, ENDPOINTS_ADMIN_GET).hasAuthority("ROLE_ADMINISTRATOR")
                         .requestMatchers(HttpMethod.POST, ENDPOINTS_ADMIN_POST).hasAuthority("ROLE_ADMINISTRATOR")
@@ -124,5 +134,22 @@ public class SecurityConfig {
         return source;
     }
 
-    
+    @Bean
+    public JavaMailSender getJavaMailSender() {
+        Dotenv dotenv = Dotenv.load();
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(dotenv.get("MAIL_USERNAME"));
+        mailSender.setPassword(dotenv.get("MAIL_PASSWORD"));
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
 }

--- a/src/main/java/com/zoonosys/security/config/SecurityConfig.java
+++ b/src/main/java/com/zoonosys/security/config/SecurityConfig.java
@@ -38,7 +38,13 @@ public class SecurityConfig {
             "/auth/reset-password/request",
             "/auth/reset-password/validate",
             "/auth/reset-password/confirm"
-    };  
+    };
+
+    public static final String [] SWAGGER_ENDPOINTS = {
+            "/swagger-ui/**",
+            "/docs/**",
+            "/v3/api-docs/**"
+    };
 
     public static final String [] ENDPOINTS_WITH_AUTHENTICATION_REQUIRED = {
             "/users/test"
@@ -89,6 +95,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/news/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/campaigns/{id}").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/reset-password/request").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/reset-password/confirm").permitAll()
                         .requestMatchers(ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED).permitAll()
                         .requestMatchers(HttpMethod.GET, ENDPOINTS_ADMIN_GET).hasAuthority("ROLE_ADMINISTRATOR")

--- a/src/main/java/com/zoonosys/services/EmailService.java
+++ b/src/main/java/com/zoonosys/services/EmailService.java
@@ -1,0 +1,4 @@
+package com.zoonosys.services;
+
+public class EmailService {
+}

--- a/src/main/java/com/zoonosys/services/EmailService.java
+++ b/src/main/java/com/zoonosys/services/EmailService.java
@@ -25,6 +25,9 @@ public class EmailService {
     @Value("${mail-from.address:noreply@zoonosys.com}")
     private String fromAddress;
 
+    @Value("${app.frontend-url}")
+    private String frontendBaseUrl;
+
     public EmailService(JavaMailSender emailSender) {
         this.emailSender = emailSender;
     }

--- a/src/main/java/com/zoonosys/services/EmailService.java
+++ b/src/main/java/com/zoonosys/services/EmailService.java
@@ -1,4 +1,61 @@
 package com.zoonosys.services;
 
+import jakarta.mail.internet.MimeMessage;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import jakarta.mail.MessagingException;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Locale;
+
+@Service
 public class EmailService {
+
+    private final JavaMailSender emailSender;
+
+    @Autowired
+    private SpringTemplateEngine templateEngine;
+
+    @Value("${mail-from.address:noreply@zoonosys.com}")
+    private String fromAddress;
+
+    public EmailService(JavaMailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
+
+    public void sendPasswordResetEmail(String toEmail, String username, String resetToken){
+        String resetUrl = "http://localhost:8080/reset-password?token=" + resetToken;
+
+        MimeMessage message = emailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(fromAddress);
+            helper.setTo(toEmail);
+            helper.setSubject("Recuperação de Senha - ZoonoSys");
+
+            Context context = new Context(new Locale("pt", "BR"));
+            context.setVariable("userName", username);
+            context.setVariable("resetUrl", resetUrl);
+            context.setVariable("token", resetToken);
+
+            String htmlContent = templateEngine.process("reset-password-email", context);
+
+            helper.setText(htmlContent, true);
+
+            emailSender.send(message);
+
+        } catch (MessagingException e){
+            logger.error("Erro ao enviar e-mail de reset de senha para {}: {}", toEmail, e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/com/zoonosys/services/PasswordResetService.java
+++ b/src/main/java/com/zoonosys/services/PasswordResetService.java
@@ -1,0 +1,4 @@
+package com.zoonosys.services;
+
+public class PasswordResetService {
+}

--- a/src/main/java/com/zoonosys/services/PasswordResetService.java
+++ b/src/main/java/com/zoonosys/services/PasswordResetService.java
@@ -1,4 +1,138 @@
 package com.zoonosys.services;
 
+import com.zoonosys.dtos.ResetPasswordConfirmationDTO;
+import com.zoonosys.dtos.ResetPasswordRequestDTO;
+import com.zoonosys.models.PasswordResetToken;
+import com.zoonosys.models.User;
+import com.zoonosys.repositories.PasswordResetTokenRepository;
+import com.zoonosys.repositories.UserRepository;
+import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
 public class PasswordResetService {
+    private static final Logger logger = LoggerFactory.getLogger(PasswordResetService.class);
+    private static final long EXPIRATION_MINUTES = 10;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordResetTokenRepository tokenRepository;
+
+    @Autowired
+    private EmailService emailService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void createAndSendResetToken(ResetPasswordRequestDTO request) {
+        Optional<User> userOptional = userRepository.findByEmail(request.email());
+
+        if(userOptional.isEmpty()) {
+            logger.warn("Tentativa de reset de senha para e-mail inexistente: {}", request.email());
+            return;
+        }
+
+        User user = userOptional.get();
+
+        tokenRepository.deleteAllByUserAndUsedIsFalse(user);
+
+        String tokenValue = UUID.randomUUID().toString();
+        LocalDateTime expiryDate = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setToken(tokenValue);
+        token.setUser(user);
+        token.setExpiryDate(expiryDate);
+
+        tokenRepository.save(token);
+        logger.info("Token de reset gerado e salvo para usuário: {}", user.getEmail());
+
+        try{
+            emailService.sendPasswordResetEmail(
+                    user.getEmail(),
+                    user.getName(),
+                    tokenValue
+            );
+            logger.info("E-mail de reset enviado com sucesso para: {}", user.getEmail());
+        } catch (Exception e){
+            logger.error("Falha ao enviar e-mail de reset para: {}", user.getEmail(), e);
+        }
+    }
+
+    /**
+     * Verifica se o token existe, não está expirado e não foi usado.
+     * @param tokenValue O valor do token recebido da URL.
+     * @return O objeto PasswordResetToken se for válido, ou Optional.empty() caso contrário.
+     */
+    public Optional<PasswordResetToken> validateToken(String tokenValue){
+        Optional<PasswordResetToken> optionalToken = tokenRepository.findByToken(tokenValue);
+
+        if(optionalToken.isEmpty()){
+            logger.warn("Validação de token falhou: Token '{}' já foi utilizado.", tokenValue);
+            return Optional.empty();
+        }
+
+        PasswordResetToken token = optionalToken.get();
+
+        if(token.isExpired()){
+            logger.warn("Validação de token falhou: Token '{}' expirou em {}.", tokenValue, token.getExpiryDate());
+            return Optional.empty();
+        }
+        logger.info("Token '{}' validado com sucesso.", tokenValue);
+        return optionalToken;
+    }
+
+    /**
+     * Confirma a redefinição de senha: valida o token, verifica senhas, atualiza e invalida o token.
+     * @param tokenValue O token de reset de senha recebido da URL.
+     * @param newPassword A nova senha.
+     * @param confirmationPassword A confirmação da nova senha.
+     * @return O objeto User com a senha atualizada (opcional).
+     */
+    @Transactional
+    public Optional<User> resetPassword(String tokenValue, String newPassword, String confirmationPassword) {
+
+        if (!newPassword.equals(confirmationPassword)) {
+            logger.warn("Redefinição falhou: Novas senhas não coincidem.");
+            return Optional.empty();
+        }
+
+        Optional<PasswordResetToken> optionalToken = validateToken(tokenValue);
+
+        if (optionalToken.isEmpty()) {
+            logger.warn("Redefinição falhou: Token inválido, expirado ou já usado.");
+            return Optional.empty();
+        }
+
+        PasswordResetToken token = optionalToken.get();
+        User user = token.getUser();
+
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            logger.warn("Redefinição falhou: A nova senha é idêntica à senha atual para o usuário: {}", user.getEmail());
+            return Optional.empty();
+        }
+
+        String hashedPassword = passwordEncoder.encode(newPassword);
+
+        user.setPassword(hashedPassword);
+        userRepository.save(user);
+
+        token.setUsed(true);
+        tokenRepository.save(token);
+
+        logger.info("Senha redefinida com sucesso e token invalidado para o usuário: {}", user.getEmail());
+
+        return Optional.of(user);
+    }
 }

--- a/src/main/java/com/zoonosys/services/PasswordResetService.java
+++ b/src/main/java/com/zoonosys/services/PasswordResetService.java
@@ -124,12 +124,10 @@ public class PasswordResetService {
         }
 
         String hashedPassword = passwordEncoder.encode(newPassword);
-
         user.setPassword(hashedPassword);
         userRepository.save(user);
 
-        token.setUsed(true);
-        tokenRepository.save(token);
+        tokenRepository.deleteAllByUserAndUsedIsFalse(user);
 
         logger.info("Senha redefinida com sucesso e token invalidado para o usuário: {}", user.getEmail());
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,9 @@ springdoc:
 # =======================================
   mail-from:
     address: noreply@zoonosys.com
+
+# =======================================
+# CONFIGURAÇÃO DO FRONT-END
+# =======================================
+app:
+  frontend-url: ${FRONTEND_URL:http://localhost:5173}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ server:
 
 spring:
   application:
-  name: demo
+    name: demo
 
 # =======================================
 # CONFIGURAÇÕES DO BANCO DE DADOS (POSTGRESQL)
@@ -15,6 +15,7 @@ spring:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:senha}
     driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -36,8 +37,31 @@ api:
 # CONFIGURAÇÕES SPRINGDOC (OpenAPI/Swagger)
 # =======================================
 springdoc:
-    api-docs:
-      path: /docs
-      pathToMatch: /api/**
-    swagger-ui:
-      use-root-path: true
+  api-docs:
+    path: /docs
+    pathToMatch: /api/**
+  swagger-ui:
+    use-root-path: true
+
+# =======================================
+# CONFIGURAÇÕES BÁSICAS DE E-MAIL (JavaMailSender)
+# =======================================
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    protocol: smtp
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+             enable: true
+          debug: true
+
+# =======================================
+# ENDEREÇO DE E-MAIL QUE APARECERÁ COMO REMETENTE
+# =======================================
+  mail-from:
+    address: noreply@zoonosys.com

--- a/src/main/resources/templates/reset-password-email.html
+++ b/src/main/resources/templates/reset-password-email.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/reset-password-email.html
+++ b/src/main/resources/templates/reset-password-email.html
@@ -8,13 +8,12 @@
 <h1 th:text="'Olá, ' + ${userName} + '!'">Olá, Usuário!</h1>
 <p>Você solicitou a recuperação de senha para sua conta no sistema ZoonoSys.</p>
 
-<p>Clique no link para redefinir sua senha:</p>
+<p>Clique no link abaixo para redefinir sua senha. Você será redirecionado para a página de criação de nova senha.</p>
 <a th:href="${resetUrl}" style="background-color: #007bff; color: white; padding: 10px 15px; text-decoration: none; border-radius: 5px;"
    th:text="'Redefinir Senha'">
     Redefinir Senha
 </a>
 
-<p>Seu código de verificação é: <strong><span th:text="${token}"></span></strong></p>
-<p>Este link/código expira em 10 minutos.</p>
+<p>Este link expira em 10 minutos. Se você não solicitou a recuperação, por favor, ignore este e-mail.</p>
 </body>
 </html>

--- a/src/main/resources/templates/reset-password-email.html
+++ b/src/main/resources/templates/reset-password-email.html
@@ -1,10 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta charset="UTF-8">
+    <title>Recuperação de Senha</title>
 </head>
 <body>
-$END$
+<h1 th:text="'Olá, ' + ${userName} + '!'">Olá, Usuário!</h1>
+<p>Você solicitou a recuperação de senha para sua conta no sistema ZoonoSys.</p>
+
+<p>Clique no link para redefinir sua senha:</p>
+<a th:href="${resetUrl}" style="background-color: #007bff; color: white; padding: 10px 15px; text-decoration: none; border-radius: 5px;"
+   th:text="'Redefinir Senha'">
+    Redefinir Senha
+</a>
+
+<p>Seu código de verificação é: <strong><span th:text="${token}"></span></strong></p>
+<p>Este link/código expira em 10 minutos.</p>
 </body>
 </html>


### PR DESCRIPTION
## Descrição
Este Pull Request implementa o fluxo completo e seguro de redefinição de senha e o valida contra falhas críticas de segurança, conforme os requisitos e testes discutidos.

## Alterações de Segurança e Arquitetura

- **Token Strategy:** Confirmado o uso de um token UUID longo, seguro e passado como Query Parameter na URL, removendo a necessidade de entrada manual de token (6 dígitos).
- **CRÍTICO: Invalidação em Massa:** Implementado o `tokenRepository.deleteAllByUserAndUsedIsFalse(user)` no final do processo de redefinição. Isso garante que, quando um token é usado com sucesso, **todos os outros tokens ativos e não usados** do usuário são imediatamente invalidados (deletados).
- **Validação de Senha:** Adicionada a regra que impede o usuário de redefinir a senha para uma que seja **idêntica** à senha atual, aumentando a segurança.
- **Refatoração do Endpoint:** O endpoint `POST /auth/reset-password/confirm` foi refatorado para receber o `token` via `@RequestParam` e as senhas via `RequestBody`, facilitando o consumo pelo Front-end.
- **Documentação:** Liberado e configurado o acesso ao Swagger UI, garantindo que o contrato da API esteja acessível em `/api/swagger-ui.html`.

A documentação (agora acessível em `/api/swagger-ui.html`) foi atualizada para refletir o seguinte:

| Parâmetro | Antiga Localização | Nova Localização | Obrigatório? | Descrição |
| :--- | :--- | :--- | :--- | :--- |
| **`token`** | Request Body | **Query Parameter (`?token=...`)** | Sim | Token UUID de redefinição. Deve ser extraído da URL pelo Front-end. |
| **`newPassword`** | Request Body | Request Body | Sim | Nova senha do usuário. |
| **`confirmationPassword`** | Request Body | Request Body | Sim | Confirmação da nova senha. |

**Verificação no Swagger:** Confirme se o `token` aparece como um parâmetro de URL separado. 

## Checklist de Revisão (Para o Revisor)

- [x] **Documentação:** Verifique se o `POST /auth/reset-password/confirm` lista o `token` corretamente como **Query Parameter** no Swagger.
- [x] **Segurança (CRÍTICO):** Teste `POST /auth/reset-password/request` duas vezes para o mesmo e-mail. Use o **primeiro** token para o `/confirm`. O segundo token deve retornar erro (400 Bad Request) devido à invalidação em massa.
- [x] **Fluxo Básico:** Confirme que o `POST /request` envia o e-mail e que o `POST /confirm` rege uma senha nova e válida.
- [x] **Validação:** Confirme que o `/confirm` retorna erro (400) se a `newPassword` for igual k gerado no e-mail aponta pà senha atual.
- [x] **E-mail/Link:** Confirme que o link gerado no e-mail aponta para o Front-end (`http://localhost:5173/reset-password/confirm?token=...`).